### PR TITLE
Fix issue with HttpUtility not available on Android

### DIFF
--- a/Packages/com.ibicha.youtube-player/Runtime/YoutubeDl.cs
+++ b/Packages/com.ibicha.youtube-player/Runtime/YoutubeDl.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Web;
 using Newtonsoft.Json;
 using UnityEngine.Networking;
 
@@ -37,7 +36,7 @@ namespace YoutubePlayer
             var requestUrl = $"{ServerUrl}/v1/video?url={youtubeUrl}";
             if (optionFlags.Count > 0)
             {
-                requestUrl += $"&options={HttpUtility.UrlEncode(string.Join(" ", optionFlags))}";
+                requestUrl += $"&options={UnityWebRequest.EscapeURL(string.Join(" ", optionFlags))}";
             }
 
             var request = UnityWebRequest.Get(requestUrl);

--- a/Packages/com.ibicha.youtube-player/package.json
+++ b/Packages/com.ibicha.youtube-player/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.ibicha.youtube-player",
   "displayName": "Youtube Player",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "unity": "2018.4",
   "keywords": [
     "video",

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ To the `scopedRegistries` section:
 To the `dependencies` section:
 
 ```
-"com.ibicha.youtube-player": "1.3.0"
+"com.ibicha.youtube-player": "1.3.1"
 ```
 
 After changes, the manifest file should look like below:
@@ -38,7 +38,7 @@ After changes, the manifest file should look like below:
     }
   ],
   "dependencies": {
-    "com.ibicha.youtube-player": "1.3.0",
+    "com.ibicha.youtube-player": "1.3.1",
     ...
 ```
 


### PR DESCRIPTION
Replace unavailable `HttpUtility.UrlEncode` with built-in similar function `UnityWebRequest.EscapeURL`
Closes #30 