### PR TITLE
Add default .ctor to json object

### DIFF
--- a/Assets/YoutubePlayer/Scripts/VideoMetadata.cs
+++ b/Assets/YoutubePlayer/Scripts/VideoMetadata.cs
@@ -9,6 +9,10 @@ namespace YoutubePlayer
         // Information about the video is provided by youtube-dl.
         public class MyYoutubeVideoMetadata : YoutubeVideoMetaData
         {
+            public MyYoutubeVideoMetadata() : base()
+            {
+            }
+
             [JsonProperty("description")]
             public string Description;
             

--- a/Packages/com.ibicha.youtube-player/Runtime/YoutubeVideoMetadata.cs
+++ b/Packages/com.ibicha.youtube-player/Runtime/YoutubeVideoMetadata.cs
@@ -4,6 +4,10 @@ namespace YoutubePlayer
 {
     public class YoutubeVideoMetaData
     {
+        public YoutubeVideoMetaData()
+        {
+        }
+
         [JsonProperty("title")]
         public string Title;
 


### PR DESCRIPTION
Add .ctor to video metadata json object in order to deserialize in IL2CPP.
Fixes #53