### PR TITLE
Use double for FPS

### DIFF
--- a/Packages/com.ibicha.youtube-player/CHANGELOG.md
+++ b/Packages/com.ibicha.youtube-player/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Added exception for when yt-dlp is missing locally
 
+### Changed
+- **BREAKING CHANGE:** Changed type `YoutubeVideoFormat.Fps` from `int` to `float`. 
+  - This is needed since youtube-dl started returning decimal numbers for frame rate, causing deserialization errors.
+
 ## [1.7.0] - 2022-07-12
 ### Added
 - Added support for yt-dlp fork - see https://github.com/yt-dlp/yt-dlp

--- a/Packages/com.ibicha.youtube-player/Runtime/YoutubePlayer.api
+++ b/Packages/com.ibicha.youtube-player/Runtime/YoutubePlayer.api
@@ -85,7 +85,7 @@ namespace YoutubePlayer
         [Newtonsoft.Json.JsonProperty(@"vcodec")] public string AudioCodec;
         [Newtonsoft.Json.JsonProperty(@"ext")] public string Extension;
         [Newtonsoft.Json.JsonProperty(@"format_id")] public string FormatId;
-        [Newtonsoft.Json.JsonProperty(@"fps")] public System.Nullable<int> Fps;
+        [Newtonsoft.Json.JsonProperty(@"fps")] public System.Nullable<double> Fps;
         [Newtonsoft.Json.JsonProperty(@"height")] public System.Nullable<int> Height;
         [Newtonsoft.Json.JsonProperty(@"url")] public string Url;
         [Newtonsoft.Json.JsonProperty(@"acodec")] public string VideoCodec;

--- a/Packages/com.ibicha.youtube-player/Runtime/YoutubeVideoFormat.cs
+++ b/Packages/com.ibicha.youtube-player/Runtime/YoutubeVideoFormat.cs
@@ -24,7 +24,7 @@ namespace YoutubePlayer
         public int? Height;
 
         [JsonProperty("fps")]
-        public int? Fps;
+        public double? Fps;
 
         [JsonProperty("vcodec")]
         public string AudioCodec;


### PR DESCRIPTION
file format of videos contains FPS, and it used to be an int, but the server started returning numbers with decimals.
Need to switch to double to prevent deserialization errors.
This is technically an api breaking change, even though minor - should perhaps bump major version.